### PR TITLE
Improve CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,14 +11,12 @@
     "test": "vitest",
     "purgecss": "purgecss --config ./purgecss.config.js"
   },
-  "dependencies": {
+  "devDependencies": {
     "@gouvfr/dsfr": "^1.9.0",
     "@gouvminint/vue-dsfr": "^3.6.0",
     "@nuxtjs/robots": "^3.0.0",
     "nuxt-simple-sitemap": "^2.6.1",
-    "vue-matomo": "^4.2.0"
-  },
-  "devDependencies": {
+    "vue-matomo": "^4.2.0",
     "@fullhuman/postcss-purgecss": "^5.0.0",
     "@nuxt/types": "^2.16.0",
     "@nuxt/typescript-build": "^3.0.0",


### PR DESCRIPTION
Ça réduit l'image scalingo de 468Mo à 168Mo.
On doit gagner quelques secondes dans le build scalingo.

On passe sur le build scalingo de :
- Sans cache de 3Minutes à 2Minutes
- Avec cache : 2Minute 20 à 1Minute 46

Environ