### PR TITLE
Erreur URL Matomo

### DIFF
--- a/client/plugins/matomo.client.ts
+++ b/client/plugins/matomo.client.ts
@@ -2,7 +2,7 @@ import VueMatomo from 'vue-matomo'
 
 export default defineNuxtPlugin((nuxtApp) => {
   nuxtApp.vueApp.use(VueMatomo, {
-    host: 'https://stats.data.gouv.fr',
+    host: 'https://stats.beta.gouv.fr',
     siteId: 22,
     // Enables automatically registering pageviews on the router
     router: nuxtApp.$router,


### PR DESCRIPTION
L'url du matomo est incorrect.
Vous avez l'id 22 sur stats.beta.gouv.fr, aucune data n'a du être collecté et vous avez du pourrir les stats de api.gouv.fr qui a a l'ID 22 sur stats.data.gouv.fr